### PR TITLE
feat(KanaoCache): seperate channel for cache and rpc

### DIFF
--- a/services/kanao-cache/src/Listeners/Caches/DispatchListener.ts
+++ b/services/kanao-cache/src/Listeners/Caches/DispatchListener.ts
@@ -48,6 +48,6 @@ export class DispatchListener extends Listener {
         const routing = new RoutedQueue(GatewayExchangeRoutes.DISPATCH, clientId)
             .shard(payload.shardId);
 
-        await container.client.amqp.publish(RabbitMQ.GATEWAY_EXCHANGE, routing.key, Buffer.from(JSON.stringify(payload.data)));
+        await container.client.cacheQueue.publish(RabbitMQ.GATEWAY_EXCHANGE, routing.key, Buffer.from(JSON.stringify(payload.data)));
     }
 }

--- a/services/kanao-cache/src/Structures/KanaoCache.ts
+++ b/services/kanao-cache/src/Structures/KanaoCache.ts
@@ -18,7 +18,7 @@ export class KanaoCache extends EventEmitter {
     });
 
     public rpcQueue = createAmqpChannel(amqp, {
-        setup: async (channel: Channel) => this.setupAmqp(channel)
+        setup: async (channel: Channel) => this.setupRpc(channel)
     });
 
     public logger = createLogger("kanao-cache", clientId, storeLogs, lokiHost);
@@ -59,7 +59,7 @@ export class KanaoCache extends EventEmitter {
         this.logger.info(`Successfully bind queue ${queue} to exchange kanao-gateway with routing key ${routingKey.key}`);
     }
 
-    public async setupAmqp(channel: Channel): Promise<void> {
+    public async setupRpc(channel: Channel): Promise<void> {
         // Used for Counts RPC
         const rpc = new RoutedQueue(`${GatewayExchangeRoutes.REQUEST}.counts`, clientId, "cache-rpc");
         await channel.assertQueue(rpc.queue, { durable: false });


### PR DESCRIPTION
This allows us to set different prefetch option.
Cache uses prefetch with the value of 1 to allow fair queue consuming across multiple cache workers
